### PR TITLE
Add from_iterator_dense function

### DIFF
--- a/src/csc.rs
+++ b/src/csc.rs
@@ -151,9 +151,9 @@ impl<'a> CscMatrix<'a> {
         CscMatrix {
             nrows,
             ncols,
-            indptr: (0..ncols+1).map(|i| i * nrows).collect::<Vec<usize>>().into(),
-            indices: iter::repeat(0..nrows).take(ncols).flatten().collect::<Vec<usize>>().into(),
-            data: buf.into()
+            indptr: Cow::Owned((0..ncols+1).map(|i| i * nrows).collect::<Vec<usize>>()),
+            indices: Cow::Owned(iter::repeat(0..nrows).take(ncols).flatten().collect::<Vec<usize>>()),
+            data: Cow::Owned(buf)
         }
     }
 
@@ -171,9 +171,9 @@ impl<'a> CscMatrix<'a> {
         CscMatrix {
             nrows,
             ncols,
-            indptr: (0..ncols+1).map(|i| i * nrows).collect::<Vec<usize>>().into(),
-            indices: iter::repeat(0..nrows).take(ncols).flatten().collect::<Vec<usize>>().into(),
-            data: slice.into()
+            indptr: Cow::Owned((0..ncols+1).map(|i| i * nrows).collect::<Vec<usize>>()),
+            indices: Cow::Owned(iter::repeat(0..nrows).take(ncols).flatten().collect::<Vec<usize>>()),
+            data: Cow::Borrowed(slice)
         }
     }
 }


### PR DESCRIPTION
This PR adds a method to create a `CrcMatrix` from an iterator. The data should be dense and in major column format. Some flavours:
 * we could use the syntax (3, 3, &[ ... ]).into() instead of CrcMatrix::from_iterator_dense(3, 3, &[ ... ])
 * different name? I wasn't sure about the `_dense`
 * use `Cow` in borrow mode without copying